### PR TITLE
feat: add container rename support and fix Docker image tag colons

### DIFF
--- a/fluid/config.py
+++ b/fluid/config.py
@@ -35,9 +35,10 @@ class ContainerRecord:
     container_id: Optional[str] = None
     image_id: Optional[str] = None
     workspace_mount: Optional[str] = None
+    custom_name: Optional[str] = None
 
     def display_name(self) -> str:
-        return self.name.removeprefix(f"{CONTAINER_PREFIX}-")
+        return self.custom_name or self.name.removeprefix(f"{CONTAINER_PREFIX}-")
 
 
 @dataclass

--- a/fluid/docker_manager.py
+++ b/fluid/docker_manager.py
@@ -287,6 +287,9 @@ def create_container_headless(
     tag_suffix = f"{distro}-{rocm_version}"
     if gpu_family:
         tag_suffix += f"-{gpu_family}"
+    # Colons are not allowed in the tag portion of a Docker
+    # image reference (only one colon separates repo:tag).
+    tag_suffix = tag_suffix.replace(":", "-")
     image_tag = f"{IMAGE_PREFIX}:{tag_suffix}"
     try:
         client.images.get(image_tag)

--- a/fluid/gui/frontend/src/App.module.css
+++ b/fluid/gui/frontend/src/App.module.css
@@ -17,4 +17,22 @@
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+.pageActive {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.pageHidden {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+  pointer-events: none;
 }

--- a/fluid/gui/frontend/src/App.tsx
+++ b/fluid/gui/frontend/src/App.tsx
@@ -9,6 +9,13 @@ import styles from "./App.module.css";
 
 export type Page = "containers" | "images" | "templates" | "settings";
 
+const pages: { key: Page; Component: React.FC }[] = [
+  { key: "containers", Component: ContainersPage },
+  { key: "images", Component: ImagesPage },
+  { key: "templates", Component: TemplatesPage },
+  { key: "settings", Component: SettingsPage },
+];
+
 export default function App() {
   const [page, setPage] = useState<Page>("containers");
 
@@ -18,10 +25,14 @@ export default function App() {
       <div className={styles.main}>
         <Header page={page} />
         <div className={styles.content}>
-          {page === "containers" && <ContainersPage />}
-          {page === "images" && <ImagesPage />}
-          {page === "templates" && <TemplatesPage />}
-          {page === "settings" && <SettingsPage />}
+          {pages.map(({ key, Component }) => (
+            <div
+              key={key}
+              className={page === key ? styles.pageActive : styles.pageHidden}
+            >
+              <Component />
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/fluid/gui/frontend/src/api/hooks.ts
+++ b/fluid/gui/frontend/src/api/hooks.ts
@@ -52,6 +52,18 @@ export function useRemoveContainer() {
   });
 }
 
+export function useRenameContainer() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ name, displayName }: { name: string; displayName: string }) =>
+      api.put<{ status: string; display_name: string }>(
+        `/containers/${name}/rename`,
+        { display_name: displayName }
+      ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["containers"] }),
+  });
+}
+
 export function useOpenInEditor() {
   return useMutation({
     mutationFn: (name: string) =>

--- a/fluid/gui/frontend/src/components/ContainerCard.module.css
+++ b/fluid/gui/frontend/src/components/ContainerCard.module.css
@@ -37,6 +37,30 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: text;
+  border-radius: var(--radius-sm);
+  padding: 1px 4px;
+  margin: -1px -4px;
+  transition: background 0.12s;
+}
+
+.name:hover {
+  background: var(--surface-raised);
+}
+
+.nameInput {
+  font-weight: 600;
+  font-size: var(--font-size-md);
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-raised);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  padding: 1px 4px;
+  margin: -1px -4px;
+  outline: none;
+  font-family: inherit;
 }
 
 .meta {

--- a/fluid/gui/frontend/src/components/ContainerCard.tsx
+++ b/fluid/gui/frontend/src/components/ContainerCard.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   useStartContainer,
   useStopContainer,
   useRemoveContainer,
+  useRenameContainer,
   useOpenInEditor,
   type ContainerInfo,
 } from "../api/hooks";
@@ -21,13 +22,31 @@ export default function ContainerCard({ container }: Props) {
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [bashKey, setBashKey] = useState(0);
   const [claudeKey, setClaudeKey] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(container.display_name);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const start = useStartContainer();
   const stop = useStopContainer();
   const remove = useRemoveContainer();
+  const rename = useRenameContainer();
   const openEditor = useOpenInEditor();
 
   const isRunning = container.status === "running";
+
+  function startEditing() {
+    setEditValue(container.display_name);
+    setEditing(true);
+    requestAnimationFrame(() => inputRef.current?.select());
+  }
+
+  function commitRename() {
+    setEditing(false);
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== container.display_name) {
+      rename.mutate({ name: container.name, displayName: trimmed });
+    }
+  }
 
   function terminalWsUrl(cmd: string) {
     return `${WS_BASE}/ws/terminal/${encodeURIComponent(container.name)}?cmd=${encodeURIComponent(cmd)}`;
@@ -46,11 +65,31 @@ export default function ContainerCard({ container }: Props) {
       <div className={styles.header}>
         <div className={styles.nameRow}>
           <span className={`status-dot ${statusClass}`} />
-          <span className={styles.name}>{container.display_name}</span>
+          {editing ? (
+            <input
+              ref={inputRef}
+              className={styles.nameInput}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitRename();
+                if (e.key === "Escape") setEditing(false);
+              }}
+              autoFocus
+            />
+          ) : (
+            <span
+              className={styles.name}
+              onDoubleClick={startEditing}
+              title="Double-click to rename"
+            >
+              {container.display_name}
+            </span>
+          )}
           <span className={`badge badge-${statusClass}`}>{container.status}</span>
         </div>
         <div className={styles.meta}>
-          <span>ROCm {container.rocm_version}</span>
           {container.workspace && (
             <span className={styles.workspace} title={container.workspace}>
               {container.workspace.replace(/^.*\//, "…/")}

--- a/fluid/gui/server.py
+++ b/fluid/gui/server.py
@@ -68,7 +68,7 @@ class QueueItem(BaseModel):
 @app.get("/api/containers")
 def list_containers() -> list[ContainerInfo]:
     import docker
-    from fluid.config import LABEL_MANAGED, LABEL_ROCM_VERSION
+    from fluid.config import LABEL_MANAGED, LABEL_ROCM_VERSION, load_state
 
     try:
         client = docker.from_env()
@@ -80,6 +80,7 @@ def list_containers() -> list[ContainerInfo]:
         filters={"label": f"{LABEL_MANAGED}=true"},
     )
 
+    state = load_state()
     results = []
     for c in containers:
         mounts = c.attrs.get("Mounts", [])
@@ -89,9 +90,13 @@ def list_containers() -> list[ContainerInfo]:
                 workspace = m.get("Source", "")
                 break
 
+        record = state.get(c.name)
+        display = (record.display_name() if record
+                   else c.name.removeprefix("fluid-"))
+
         results.append(ContainerInfo(
             name=c.name,
-            display_name=c.name.removeprefix("fluid-"),
+            display_name=display,
             status=c.status,
             rocm_version=c.labels.get(LABEL_ROCM_VERSION, "?"),
             workspace=workspace,
@@ -206,6 +211,9 @@ async def create_container_ws(websocket: WebSocket):
                 tag_suffix = f"{distro}-{rocm_version}"
                 if gpu_family:
                     tag_suffix += f"-{gpu_family}"
+                # Colons are not allowed in the tag portion of a Docker
+                # image reference (only one colon separates repo:tag).
+                tag_suffix = tag_suffix.replace(":", "-")
                 image_tag = f"{IMAGE_PREFIX}:{tag_suffix}"
 
             try:
@@ -384,6 +392,44 @@ async def create_container_ws(websocket: WebSocket):
         await websocket.close()
     except Exception:
         pass
+
+
+class RenameRequest(BaseModel):
+    display_name: str
+
+
+@app.put("/api/containers/{name}/rename")
+def rename_container(name: str, req: RenameRequest) -> dict:
+    from fluid.config import CONTAINER_PREFIX, load_state, save_state
+
+    import docker
+
+    client = docker.from_env()
+    try:
+        container = client.containers.get(name)
+    except docker.errors.NotFound:
+        try:
+            container = client.containers.get(f"{CONTAINER_PREFIX}-{name}")
+            name = container.name
+        except docker.errors.NotFound:
+            return {"error": f"Container {name} not found"}
+
+    real_name = container.name
+    new_display = req.display_name.strip()
+    if not new_display:
+        return {"error": "Display name cannot be empty"}
+
+    state = load_state()
+    record = state.get(real_name)
+    if record:
+        record.custom_name = new_display
+        save_state(state)
+
+    return {
+        "status": "renamed",
+        "name": real_name,
+        "display_name": new_display,
+    }
 
 
 @app.post("/api/containers/{name}/start")

--- a/fluid/templates.py
+++ b/fluid/templates.py
@@ -124,11 +124,14 @@ def make_image_tag(
 
     Produces tags like::
 
-        fluid:pytorch-rocm-rocm:6.4-torch:2.5
-        fluid:fluid-base-base:ubuntu-22.04
+        fluid:pytorch-rocm-rocm--6.4-torch--2.5
+        fluid:fluid-base-base--ubuntu-22.04
 
     The tag portion (after the ``:``) is capped at 50 characters.
     Args are appended in declaration order until the budget runs out.
+
+    The tag portion must never contain ``:``, as Docker references only
+    allow a single colon separating repository from tag.
     """
     template_slug = _sanitize_tag_part(template.name)
 
@@ -162,6 +165,9 @@ def make_image_tag(
         used += needed
 
     tag = "-".join(parts)
+    # Safety: ensure no stray colons survive in the tag portion –
+    # Docker only allows one colon (repo:tag).
+    tag = tag.replace(":", "-")
     return f"{prefix}:{tag}"
 
 


### PR DESCRIPTION
Add the ability to rename containers via a custom display name:
- Add `custom_name` field to ContainerRecord for persistent renaming
- Add PUT /api/containers/{name}/rename endpoint in the GUI server
- Add useRenameContainer hook and inline-edit UI on ContainerCard (double-click the name to rename, Enter to confirm, Escape to cancel)
- Display names now resolve from saved state via ContainerRecord.display_name()

Fix Docker image tag generation containing illegal colons:
- Replace colons with hyphens in tag_suffix across docker_manager, server.py, and templates.py (Docker only allows one colon for repo:tag)

Improve frontend page rendering:
- Switch from conditional rendering to persistent mount with CSS visibility toggling, preserving terminal state across page switches
- Remove redundant ROCm version display from ContainerCard meta row